### PR TITLE
Add powerai-based multiarch Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,52 +3,53 @@ language: python
 python:
   - 3.6
 
-os:
-  - linux
-  - linux-ppc64le
-
-env:
-  - DOCKERFILE=Dockerfile IMAGE=max-base
-  - DOCKERFILE=Dockerfile.pai IMAGE=max-base-powerai
-
-matrix:
-  exclude:
-  - env: DOCKERFILE=Dockerfile IMAGE=max-base
-    os: linux-ppc64le
-
-dist: xenial
-
 services:
   - docker
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux-ppc64le" ]]; then
-       ARCH=ppc64le;
+  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then
+      VERSION=latest;
+    else
+      VERSION=$TRAVIS_BRANCH;
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-       ARCH=x86_64;
-    fi
-  - mkdir -p ~/.docker
-  - echo '{"experimental":"enabled"}' | tee ~/.docker/config.json 
-  - sudo service docker restart
 
 install:
-  - docker build -f "$DOCKERFILE" -t "$REPO"/"$IMAGE":"$ARCH"-latest .
+  - docker build -f "$DOCKERFILE" -t mborgard/max-base:"$IMAGE"-"$ARCH"-"$VERSION" .
 
 before_script:
-  - docker run -it --rm -d -p 5000:5000 "$REPO"/"$IMAGE":"$ARCH"-latest
+  - docker run -it --rm -d -p 5000:5000 mborgard/max-base:"$IMAGE"-"$ARCH"-"$VERSION"
   - sleep 10
 
 script:
-  - docker ps | grep "$IMAGE"
+  - docker ps | grep ajbozarth/max-base:"$IMAGE"-"$ARCH"-"$VERSION"
 
 after_success:
-  - if [[ "$IMAGE" != "max-base" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-      docker login -u "$REPO_USER" -p "$REPO_PASS";
-      docker push "$REPO"/"$IMAGE":"$ARCH"-latest;
-      docker pull "$REPO"/"$IMAGE":ppc64le-latest;
-      docker pull "$REPO"/"$IMAGE":x86_64-latest;
-      docker manifest create "$REPO"/"$IMAGE":latest "$REPO"/"$IMAGE":ppc64le-latest "$REPO"/"$IMAGE":x86_64-latest;
-      docker manifest push "$REPO"/"$IMAGE":latest;
+  - if [[ "$IMAGE" != "test" && "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ "$TRAVIS_BRANCH" == "master" || "$TRAVIS_BRANCH" == "$TRAVIS_TAG" ]]; then
+      echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin;
+      docker push ajbozarth/max-base:"$IMAGE"-"$ARCH"-"$VERSION";
     fi
 
+matrix:
+  include:
+  - os: linux
+    env: DOCKERFILE=Dockerfile IMAGE=test ARCH=x86_64
+  - os: linux
+    env: DOCKERFILE=Dockerfile.pai IMAGE=powerai ARCH=x86_64
+  - os: linux-ppc64le
+    env: DOCKERFILE=Dockerfile.pai IMAGE=powerai ARCH=ppc64le
+  - if: type = push AND (branch = master OR tag IS present)
+    stage: "Docker Manifest"
+    addons:
+      apt:
+        packages:
+          - docker-ce
+    install:
+    before_script:
+    script:
+      - export DOCKER_CLI_EXPERIMENTAL=enabled
+      - echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin;
+      - docker pull mborgard/max-base:powerai-ppc64le-"$VERSION";
+      - docker pull mborgard/max-base:powerai-x86_64-"$VERSION";
+      - docker manifest create mborgard/max-base:powerai-"$VERSION" mborgard/max-base:powerai-ppc64le-"$VERSION" mborgard/max-base:powerai-x86_64-"$VERSION";
+      - docker manifest push mborgard/max-base:powerai-"$VERSION";
+    after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script:
   - docker ps | grep "$IMAGE"
 
 after_success:
-  - if [[ "$IMAGE" != "max-base" ]]; then
+  - if [[ "$IMAGE" != "max-base" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
       docker login -u "$REPO_USER" -p "$REPO_PASS";
       docker push "$REPO"/"$IMAGE":"$ARCH"-latest;
       docker pull "$REPO"/"$IMAGE":ppc64le-latest;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,40 @@ language: python
 python:
   - 3.6
 
+os:
+  - linux
+  - linux-ppc64le
+
+dist: xenial
+
 services:
   - docker
 
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux-ppc64le" ]]; then
+       ARCH=ppc64le;
+    fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+       ARCH=x86_64;
+    fi
+  - mkdir -p ~/.docker
+  - echo '{"experimental":"enabled"}' | tee ~/.docker/config.json 
+  - sudo service docker restart
+
 install:
-  - docker build -t max-base .
+  - docker build -f Dockerfile.pai -t "$REPO"/max-base-powerai:"$ARCH"-latest .
 
 before_script:
-  - docker run -it --rm -d -p 5000:5000 max-base
+  - docker run -it --rm -d -p 5000:5000 "$REPO"/max-base-powerai:"$ARCH"-latest
   - sleep 10
 
 script:
-  - docker ps | grep max-base
+  - docker ps | grep max-base-powerai
+
+after_success:
+  - docker login -u "$REPO_USER" -p "$REPO_PASS"
+  - docker push "$REPO"/max-base-powerai:"$ARCH"-latest
+  - docker pull "$REPO"/max-base-powerai:ppc64le-latest
+  - docker pull "$REPO"/max-base-powerai:x86_64-latest
+  - docker manifest create "$REPO"/max-base-powerai:latest "$REPO"/max-base-powerai:ppc64le-latest "$REPO"/max-base-powerai:x86_64-latest
+  - docker manifest push "$REPO"/max-base-powerai:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,15 @@ os:
   - linux
   - linux-ppc64le
 
+env:
+  - DOCKERFILE=Dockerfile IMAGE=max-base
+  - DOCKERFILE=Dockerfile.pai IMAGE=max-base-powerai
+
+matrix:
+  exclude:
+  - env: DOCKERFILE=Dockerfile IMAGE=max-base
+    os: linux-ppc64le
+
 dist: xenial
 
 services:
@@ -23,19 +32,21 @@ before_install:
   - sudo service docker restart
 
 install:
-  - docker build -f Dockerfile.pai -t "$REPO"/max-base-powerai:"$ARCH"-latest .
+  - docker build -f "$DOCKERFILE" -t "$REPO"/"$IMAGE":"$ARCH"-latest .
 
 before_script:
-  - docker run -it --rm -d -p 5000:5000 "$REPO"/max-base-powerai:"$ARCH"-latest
+  - docker run -it --rm -d -p 5000:5000 "$REPO"/"$IMAGE":"$ARCH"-latest
   - sleep 10
 
 script:
-  - docker ps | grep max-base-powerai
+  - docker ps | grep "$IMAGE"
 
 after_success:
-  - docker login -u "$REPO_USER" -p "$REPO_PASS"
-  - docker push "$REPO"/max-base-powerai:"$ARCH"-latest
-  - docker pull "$REPO"/max-base-powerai:ppc64le-latest
-  - docker pull "$REPO"/max-base-powerai:x86_64-latest
-  - docker manifest create "$REPO"/max-base-powerai:latest "$REPO"/max-base-powerai:ppc64le-latest "$REPO"/max-base-powerai:x86_64-latest
-  - docker manifest push "$REPO"/max-base-powerai:latest
+  - if [[ "$IMAGE" != "max-base" ]]; then
+    docker login -u "$REPO_USER" -p "$REPO_PASS";
+    docker push "$REPO"/"$IMAGE":"$ARCH"-latest;
+    docker pull "$REPO"/"$IMAGE":ppc64le-latest;
+    docker pull "$REPO"/"$IMAGE":x86_64-latest;
+    docker manifest create "$REPO"/"$IMAGE":latest "$REPO"/"$IMAGE":ppc64le-latest "$REPO"/"$IMAGE":x86_64-latest;
+    docker manifest push "$REPO"/"$IMAGE":latest
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+
 python:
   - 3.6
 
@@ -43,10 +44,11 @@ script:
 
 after_success:
   - if [[ "$IMAGE" != "max-base" ]]; then
-    docker login -u "$REPO_USER" -p "$REPO_PASS";
-    docker push "$REPO"/"$IMAGE":"$ARCH"-latest;
-    docker pull "$REPO"/"$IMAGE":ppc64le-latest;
-    docker pull "$REPO"/"$IMAGE":x86_64-latest;
-    docker manifest create "$REPO"/"$IMAGE":latest "$REPO"/"$IMAGE":ppc64le-latest "$REPO"/"$IMAGE":x86_64-latest;
-    docker manifest push "$REPO"/"$IMAGE":latest
-  fi
+      docker login -u "$REPO_USER" -p "$REPO_PASS";
+      docker push "$REPO"/"$IMAGE":"$ARCH"-latest;
+      docker pull "$REPO"/"$IMAGE":ppc64le-latest;
+      docker pull "$REPO"/"$IMAGE":x86_64-latest;
+      docker manifest create "$REPO"/"$IMAGE":latest "$REPO"/"$IMAGE":ppc64le-latest "$REPO"/"$IMAGE":x86_64-latest;
+      docker manifest push "$REPO"/"$IMAGE":latest;
+    fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,19 @@ before_install:
     fi
 
 install:
-  - docker build -f "$DOCKERFILE" -t mborgard/max-base:"$IMAGE"-"$ARCH"-"$VERSION" .
+  - docker build -f "$DOCKERFILE" -t codait/max-base:"$IMAGE"-"$ARCH"-"$VERSION" .
 
 before_script:
-  - docker run -it --rm -d -p 5000:5000 mborgard/max-base:"$IMAGE"-"$ARCH"-"$VERSION"
+  - docker run -it --rm -d -p 5000:5000 codait/max-base:"$IMAGE"-"$ARCH"-"$VERSION"
   - sleep 10
 
 script:
-  - docker ps | grep ajbozarth/max-base:"$IMAGE"-"$ARCH"-"$VERSION"
+  - docker ps | grep codait/max-base:"$IMAGE"-"$ARCH"-"$VERSION"
 
 after_success:
   - if [[ "$IMAGE" != "test" && "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ "$TRAVIS_BRANCH" == "master" || "$TRAVIS_BRANCH" == "$TRAVIS_TAG" ]]; then
       echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin;
-      docker push ajbozarth/max-base:"$IMAGE"-"$ARCH"-"$VERSION";
+      docker push codait/max-base:"$IMAGE"-"$ARCH"-"$VERSION";
     fi
 
 matrix:
@@ -48,8 +48,8 @@ matrix:
     script:
       - export DOCKER_CLI_EXPERIMENTAL=enabled
       - echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin;
-      - docker pull mborgard/max-base:powerai-ppc64le-"$VERSION";
-      - docker pull mborgard/max-base:powerai-x86_64-"$VERSION";
-      - docker manifest create mborgard/max-base:powerai-"$VERSION" mborgard/max-base:powerai-ppc64le-"$VERSION" mborgard/max-base:powerai-x86_64-"$VERSION";
-      - docker manifest push mborgard/max-base:powerai-"$VERSION";
+      - docker pull codait/max-base:powerai-ppc64le-"$VERSION";
+      - docker pull codait/max-base:powerai-x86_64-"$VERSION";
+      - docker manifest create codait/max-base:powerai-"$VERSION" codait/max-base:powerai-ppc64le-"$VERSION" codait/max-base:powerai-x86_64-"$VERSION";
+      - docker manifest push codait/max-base:powerai-"$VERSION";
     after_success:

--- a/Dockerfile.pai
+++ b/Dockerfile.pai
@@ -1,0 +1,13 @@
+FROM ibmcom/powerai:1.6.0-base-ubuntu18.04-py3
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /workspace
+RUN mkdir assets
+
+COPY requirements.txt /workspace
+RUN cd /opt/anaconda3/bin && \
+        source activate base && \
+	pip install --upgrade pip &&\
+        pip install -r /workspace/requirements.txt
+
+COPY . /workspace

--- a/Dockerfile.pai
+++ b/Dockerfile.pai
@@ -4,10 +4,8 @@ SHELL ["/bin/bash", "-c"]
 WORKDIR /workspace
 RUN mkdir assets
 
-COPY requirements.txt /workspace
+COPY . .
 RUN cd /opt/anaconda3/bin && \
         source activate base && \
 	pip install --upgrade pip &&\
         pip install -r /workspace/requirements.txt
-
-COPY . /workspace


### PR DESCRIPTION
This Dockerfile will create an empty (i.e., no deep learning frameworks) IBM PowerAI-based container with the MAX framework software installed.

Note that currently powerai 1.6.0 is gpu-based only, meaning any subsequent images based FROM this one will need access to GPU hardware (usually via nvidia-docker).