### PR TITLE
Avoid explicitly using /workspace. Use dot (.) instead.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM continuumio/miniconda3:4.5.4
 WORKDIR /workspace
 RUN mkdir assets
 
-COPY requirements.txt /workspace
+COPY . .
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
-
-COPY . /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,4 @@ WORKDIR /workspace
 RUN mkdir assets
 
 COPY . .
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
+RUN pip install --upgrade pip && pip install -r requirements.txt


### PR DESCRIPTION
- Avoid explicitly using /workspace . Use dot (.) instead.
- Do not create an additional layer for upgraded pip.