### PR TITLE
Add arm32v7 support for MAX base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ matrix:
   - os: linux
     env: DOCKERFILE=Dockerfile IMAGE=test ARCH=x86_64
   - os: linux
+    arch: arm64
+    env: DOCKERFILE=Dockerfile.arm32v7 IMAGE=test ARCH=arm32v7
+  - os: linux
     env: DOCKERFILE=Dockerfile.pai IMAGE=powerai ARCH=x86_64
   - os: linux-ppc64le
     env: DOCKERFILE=Dockerfile.pai IMAGE=powerai ARCH=ppc64le

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,9 @@
+FROM arm32v7/python:3.6.9-buster
+
+# arm32v7 is the CPU that is integrated into Raspberry PI 4
+
+WORKDIR /workspace
+RUN mkdir assets
+
+COPY . .
+RUN pip install --upgrade pip && pip install -r requirements.txt

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,6 +1,6 @@
 FROM arm32v7/python:3.6.9-buster
 
-# arm32v7 is the CPU that is integrated into Raspberry PI 4
+# arm32v7 is the CPU that is integrated into Raspberry Pi 4
 
 WORKDIR /workspace
 RUN mkdir assets


### PR DESCRIPTION
Currently pushing to Docker hub is intentionally left out, until we have tested a bit more.