### PR TITLE
ARM: Switch to Python 3.7 and enable piwheel

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,9 +1,12 @@
-FROM arm32v7/python:3.6.9-buster
+FROM arm32v7/python:3.7.5-buster
 
 # arm32v7 is the CPU that is integrated into Raspberry Pi 4
 
 WORKDIR /workspace
 RUN mkdir assets
+
+# Enable piwheels
+RUN echo "[global]\nextra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf
 
 COPY . .
 RUN pip install --upgrade pip && pip install -r requirements.txt


### PR DESCRIPTION
Python 3.7 is far better supported than Python 3.6 on Raspberry Pi,
because there was no stable Debian including Python 3.6 (Debian 9 uses
Python 3.5 and Debian 10 uses Python 3.7). We can make the switch at
least for ARM now if there is no specific reason that we are stuck on
Python 3.6.