### PR TITLE
Upgrade base image to continuumio/miniconda3:4.7.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:4.5.4
+FROM continuumio/miniconda3:4.7.12
 
 WORKDIR /workspace
 RUN mkdir assets


### PR DESCRIPTION
The latest image uses Python 3.7: https://github.com/ContinuumIO/docker-images/tree/master/miniconda3