### PR TITLE
Use flask-restx instead of flask-restplus

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask-restplus==0.11.0
+flask-restx==0.1.1
 flask-cors==3.0.7
 maxfw==1.1.3


### PR DESCRIPTION
flask-restx is a drop in replacement of flask-restplus. Flask-restplus is no longer maintained. See https://github.com/noirbizarre/flask-restplus#flask-restplus

