### PR TITLE
Bump maxfw to 1.1.5

### DIFF
--- a/Dockerfile.pai
+++ b/Dockerfile.pai
@@ -22,8 +22,21 @@ RUN sudo install -g pwrai -o pwrai -d /workspace
 WORKDIR /workspace
 RUN mkdir assets
 
+# Dependencies for building NumPy and Pillow (Prebuilt NumPy and Pillow are not available for ppc)
+RUN sudo apt-get update && sudo apt-get install -y \
+      build-essential \
+      # NumPy
+      gfortran \
+      libblas-dev \
+      liblapack-dev \
+      # Pillow
+      libjpeg-dev \
+      zlib1g-dev \
+      && sudo rm -rf /var/lib/apt/lists/*
+
 COPY . .
-RUN ["/bin/bash", "-c", "cd /opt/anaconda/bin && source activate base && pip install --upgrade pip && pip install -r /workspace/requirements.txt" ]
+# Cython is required for building NumPy
+RUN ["/bin/bash", "-c", "cd /opt/anaconda/bin && source activate base && pip install --upgrade pip && pip install Cython --install-option='--no-cython-compile' && pip install -r /workspace/requirements.txt" ]
 
 #The following is required to get flask to work with the version of werkzeug (0.14) available in PowerAI
 RUN ["/bin/bash", "-c", "cd /opt/anaconda/bin && source activate base && pip install Flask==1.0.2"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-flask-restx==0.3
 flask-cors==3.0.7
-maxfw==1.1.3
+maxfw==1.1.5


### PR DESCRIPTION
Removed flask-restx requirement because maxfw already fixed flask-restx version.
