### PR TITLE
Bump max framework to 1.1.6 and add back flask-restx to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-flask-cors==3.0.7
-maxfw==1.1.5
+flask-cors==3.0.9
+flask-restx==0.3.0
+maxfw==1.1.6


### PR DESCRIPTION
<!-- If you have edited one of the Dockerfiles, please don't forget to make applicable changes to the Dockerfiles for the other CPU architectures. -->
