### PR TITLE
Pin Python version to 3.7.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ USER max
 WORKDIR /home/max
 RUN mkdir assets
 COPY . .
+RUN conda install python==3.7.10
 RUN pip install --upgrade pip && pip install -r requirements.txt


### PR DESCRIPTION
Tensorflow 1.15.x doesn't support python 3.8

<!-- If you have edited one of the Dockerfiles, please don't forget to make applicable changes to the Dockerfiles for the other CPU architectures. -->
