### PR TITLE
flask-restx 0.3.0 doesn't work with flask 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 flask-cors==3.0.9
 flask-restx==0.3.0
+# The following line is a hack: flask-restx doesn't work with flask 2.0. Once flask-restx fixed the issue, the following line should be removed
+flask>=1.1.2,<2.0
 maxfw==1.1.6


### PR DESCRIPTION
Looks like we hit flask's release spot: flask 2.0 was released earlier
today two hours ago, which are within the window in which we released a
new MAX Base version after test. Fix flask < 2.0 for now.

<!-- If you have edited one of the Dockerfiles, please don't forget to make applicable changes to the Dockerfiles for the other CPU architectures. -->
