### PR TITLE
Pin flask to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask-cors==3.0.10
 flask-restx==0.5.0
-flask==1.1.4,<2.0
+flask==2.0.1
 maxfw==1.1.6


### PR DESCRIPTION
flask-restx has supported flask 2.0 now

See the compatibility table in https://github.com/python-restx/flask-restx

<!-- If you have edited one of the Dockerfiles, please don't forget to make applicable changes to the Dockerfiles for the other CPU architectures. -->
