### PR TITLE
Don't use cache dir for pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ WORKDIR /home/max
 RUN mkdir assets
 COPY . .
 RUN conda install python==3.7.11
-RUN pip install --upgrade pip && pip install -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -31,5 +31,5 @@ WORKDIR /home/max
 RUN mkdir assets
 
 COPY . .
-RUN pip install --upgrade pip && pip install -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
For example, see https://github.com/IBM/MAX-Object-Detector/issues/163

<!-- If you have edited one of the Dockerfiles, please don't forget to make applicable changes to the Dockerfiles for the other CPU architectures. -->
