### PR TITLE
Use bash shell with pipefail option turned on when building the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@
 
 FROM continuumio/miniconda3:4.10.3
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Upgrade all packages to meet security criteria
 RUN apt-get update && apt-get upgrade -y && apt-get install sudo && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -16,6 +16,8 @@
 
 FROM arm32v7/python:3.7.11-buster
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Upgrade all packages to meet security criteria
 RUN apt-get update && apt-get upgrade -y && apt-get install sudo && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
<!-- If you have edited one of the Dockerfiles, please don't forget to make applicable changes to the Dockerfiles for the other CPU architectures. -->
